### PR TITLE
Implement Avtor24 auction bot MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Avtor24 Auction Bot
+
+This project provides an MVP implementation of a browser-driven automation bot for Avtor24 auctions. The bot monitors new orders, prioritises bids, places offers through a Playwright-controlled browser, and schedules follow-up communication.
+
+## Features
+
+- Per-account configuration with individual filters, templates, and pacing controls.
+- GraphQL client for fetching auctions, preparing orders, and sending bids/messages.
+- Priority queue that emphasises new orders while keeping the backlog fresh.
+- Browser automation routines that mimic user interactions and support manual captcha solving.
+- Scheduler for delayed follow-up messages and interval enforcement between bids.
+- Resilient worker supervision with automatic reconnection and logging hooks.
+
+## Project Layout
+
+- `src/auction_bot/` — core package with modules for configuration, queue management, GraphQL access, and workers.
+- `config/` — example configuration files per account.
+- `pyproject.toml` — project metadata and runtime dependencies.
+
+## Usage
+
+1. Install dependencies and Playwright browsers:
+   ```bash
+   pip install -e .
+   playwright install
+   ```
+2. Prepare account configuration files inside `config/` (copy and adapt the example file).
+3. Launch the bot:
+   ```bash
+   avtor24-bot --config-dir config
+   ```
+
+The bot starts a dedicated worker per account, opens a Playwright-controlled Chromium window for manual captcha solving, and begins monitoring auctions according to the configured filters and pacing parameters.
+
+## Packaging
+
+To produce a standalone executable on Windows, build the project and feed it to PyInstaller:
+
+```bash
+pip install pyinstaller
+pyinstaller --name avtor24-bot --onefile -p src/ auction_bot/__main__.py
+```
+
+Include the generated executable together with the `config/` directory and instructions for the operator.

--- a/config/example_account.yaml
+++ b/config/example_account.yaml
@@ -1,0 +1,18 @@
+name: demo
+login: user@example.com
+password: secret
+min_seconds_between_bids: 3
+max_seconds_between_bids: 6
+follow_up_delay_minutes: 5
+filters:
+  subjects: ["Юриспруденция"]
+  work_types: ["Доклад", "Статья"]
+  min_budget: 500
+message_templates:
+  - name: "base"
+    text: "Здравствуйте! Готов выполнить заказ качественно и в срок."
+    delay_seconds: 0
+  - name: "followup"
+    text: "Хотел уточнить, готовы ли обсудить детали заказа?"
+    delay_seconds: 600
+headless: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "auction-bot"
+version = "0.1.0"
+description = "Automation bot for Avtor24 auctions"
+authors = [{name = "AutoDev"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "httpx[http2]~=0.27.0",
+    "pydantic~=2.6",
+    "PyYAML~=6.0",
+    "playwright~=1.41",
+    "tenacity~=8.2",
+]
+
+[project.scripts]
+avtor24-bot = "auction_bot.__main__:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/auction_bot/__init__.py
+++ b/src/auction_bot/__init__.py
@@ -1,0 +1,9 @@
+"""Core package for the Avtor24 auction bot."""
+
+__all__ = [
+    "config",
+    "graphql",
+    "queue",
+    "browser",
+    "worker",
+]

--- a/src/auction_bot/__main__.py
+++ b/src/auction_bot/__main__.py
@@ -1,0 +1,45 @@
+"""CLI entry point for the Avtor24 auction bot."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+from .config import load_config_directory
+from .worker import run_workers
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Avtor24 auction bot")
+    parser.add_argument(
+        "--config-dir",
+        type=Path,
+        required=True,
+        help="Directory containing per-account YAML configs",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    _configure_logging(args.verbose)
+    configs = load_config_directory(args.config_dir)
+    asyncio.run(run_workers(configs))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/auction_bot/browser.py
+++ b/src/auction_bot/browser.py
@@ -1,0 +1,118 @@
+"""Playwright-based browser automation helpers."""
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import AsyncIterator, Awaitable, Callable, Optional
+
+from playwright.async_api import Browser, BrowserContext, Page, Playwright, async_playwright
+
+LOGGER = logging.getLogger(__name__)
+
+LOGIN_URL = "https://avtor24.ru/login"
+SEARCH_URL = "https://avtor24.ru/order/search"
+ORDER_URL_TEMPLATE = "https://avtor24.ru/order/{order_id}"
+
+
+class BrowserSession:
+    """Wrapper around a Playwright browser context."""
+
+    def __init__(self, storage_path: Path, headless: bool = False) -> None:
+        self.storage_path = storage_path
+        self.headless = headless
+        self._playwright: Optional[Playwright] = None
+        self._browser: Optional[Browser] = None
+        self._context: Optional[BrowserContext] = None
+        self._page: Optional[Page] = None
+
+    async def start(self) -> Page:
+        LOGGER.info("Launching browser (headless=%s) with storage at %s", self.headless, self.storage_path)
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        self._playwright = await async_playwright().start()
+        self._browser = await self._playwright.chromium.launch(headless=self.headless)
+        storage_state = str(self.storage_path) if self.storage_path.exists() else None
+        self._context = await self._browser.new_context(storage_state=storage_state)
+        self._page = await self._context.new_page()
+        return self._page
+
+    async def stop(self) -> None:
+        if self._context and self.storage_path:
+            LOGGER.info("Saving storage state to %s", self.storage_path)
+            await self._context.storage_state(path=str(self.storage_path))
+        if self._browser:
+            await self._browser.close()
+        if self._playwright:
+            await self._playwright.stop()
+
+    @property
+    def page(self) -> Page:
+        if not self._page:
+            raise RuntimeError("Browser session not started")
+        return self._page
+
+    async def ensure_logged_in(self, login: str, password: str) -> None:
+        """Navigate to the login form and ensure the user is authenticated."""
+
+        page = self.page
+        await page.goto(SEARCH_URL)
+        if "login" not in page.url:
+            LOGGER.debug("Already authenticated")
+            return
+        LOGGER.info("Logging in as %s", login)
+        await page.goto(LOGIN_URL)
+        await page.fill("input[name=email]", login)
+        await page.fill("input[name=password]", password)
+        await page.click("button[type=submit]")
+        await page.wait_for_url(SEARCH_URL, timeout=30000)
+        LOGGER.info("Authentication successful")
+
+    async def open_order(self, order_id: str) -> None:
+        url = ORDER_URL_TEMPLATE.format(order_id=order_id)
+        LOGGER.debug("Opening order page %s", url)
+        await self.page.goto(url)
+        await self.page.wait_for_selector("[data-testid='MakeOffer__inputBid']", timeout=15000)
+
+    async def place_bid(self, amount: float, message: str, *, captcha_required: bool) -> None:
+        page = self.page
+        await page.hover("[data-testid='MakeOffer__inputBid']")
+        await page.click("[data-testid='MakeOffer__inputBid']")
+        await page.fill("[data-testid='MakeOffer__inputBid']", str(int(amount)))
+        await page.fill("textarea#makeOffer_comment", message)
+        await page.mouse.move(300, 600, steps=5)
+        await page.wait_for_timeout(400)
+        button = page.locator("button:has-text('Поставить ставку')")
+        await button.scroll_into_view_if_needed()
+        await button.click()
+        if captcha_required:
+            LOGGER.warning("Captcha detected. Awaiting manual resolution...")
+            await page.wait_for_selector(".smart-captcha", state="hidden", timeout=180000)
+        await page.wait_for_timeout(1000)
+
+    async def send_followup_message(self, text: str) -> None:
+        page = self.page
+        await page.fill("textarea#makeOffer_comment", text)
+        await page.wait_for_timeout(300)
+        await page.click("button:has-text('Отправить')")
+
+
+@asynccontextmanager
+async def playwright_session(storage_path: Path, headless: bool = False) -> AsyncIterator[BrowserSession]:
+    session = BrowserSession(storage_path=storage_path, headless=headless)
+    try:
+        await session.start()
+        yield session
+    finally:
+        await session.stop()
+
+
+async def with_browser(
+    storage_path: Path,
+    headless: bool,
+    coro: Callable[[BrowserSession], Awaitable[None]],
+) -> None:
+    async with playwright_session(storage_path, headless=headless) as session:
+        await coro(session)
+
+
+__all__ = ["BrowserSession", "playwright_session", "with_browser"]

--- a/src/auction_bot/config.py
+++ b/src/auction_bot/config.py
@@ -1,0 +1,118 @@
+"""Configuration models and helpers for the Avtor24 auction bot."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import yaml
+from pydantic import BaseModel, Field, validator
+
+
+class MessageTemplate(BaseModel):
+    """Template for automatic messages."""
+
+    name: str = Field(..., description="Human readable identifier")
+    text: str = Field(..., description="Message body with placeholders")
+    delay_seconds: int = Field(
+        0,
+        ge=0,
+        description="Delay before sending the message once the bid succeeds",
+    )
+
+
+class OrderFilters(BaseModel):
+    """Filters applied when fetching available orders."""
+
+    subjects: List[str] = Field(default_factory=list)
+    work_types: List[str] = Field(default_factory=list)
+    min_budget: Optional[int] = Field(
+        None, ge=0, description="Minimum acceptable budget in roubles"
+    )
+    max_budget: Optional[int] = Field(
+        None, ge=0, description="Maximum acceptable budget in roubles"
+    )
+
+    @validator("max_budget")
+    def _validate_budget(cls, value: Optional[int], values: dict[str, object]) -> Optional[int]:
+        min_budget = values.get("min_budget")
+        if value is not None and min_budget is not None and value < min_budget:
+            raise ValueError("max_budget must be greater than or equal to min_budget")
+        return value
+
+
+class AccountConfig(BaseModel):
+    """Configuration for a single account."""
+
+    name: str = Field(..., description="Short account nickname")
+    login: str = Field(..., description="Account login/email")
+    password: str = Field(..., description="Account password")
+    min_seconds_between_bids: int = Field(
+        3,
+        ge=1,
+        description="Lower bound for the interval between bids",
+    )
+    max_seconds_between_bids: int = Field(
+        3,
+        ge=1,
+        description="Upper bound for jitter around bid intervals",
+    )
+    follow_up_delay_minutes: int = Field(
+        5,
+        ge=0,
+        description="Default delay before sending a follow-up message",
+    )
+    filters: OrderFilters = Field(default_factory=OrderFilters)
+    message_templates: List[MessageTemplate] = Field(default_factory=list)
+    headless: bool = Field(
+        False,
+        description="Run the Playwright browser in headless mode (not recommended)",
+    )
+    storage_path: Optional[Path] = Field(
+        None,
+        description="Path for storing cookies/session data; defaults to config file directory",
+    )
+
+    @validator("max_seconds_between_bids")
+    def _validate_interval(
+        cls, value: int, values: dict[str, object]
+    ) -> int:
+        min_seconds = values.get("min_seconds_between_bids", 0)
+        if value < min_seconds:
+            raise ValueError("max_seconds_between_bids must be >= min_seconds_between_bids")
+        return value
+
+
+class BotConfig(BaseModel):
+    """Top-level configuration."""
+
+    accounts: List[AccountConfig]
+
+
+def load_account_config(path: Path) -> AccountConfig:
+    """Load a single account configuration from a YAML file."""
+
+    with path.open("r", encoding="utf-8") as stream:
+        payload = yaml.safe_load(stream)
+    account = AccountConfig.parse_obj(payload)
+    if account.storage_path is None:
+        account.storage_path = path.parent / f"{account.name}_storage"
+    return account
+
+
+def load_config_directory(config_dir: Path) -> List[AccountConfig]:
+    """Load all account configs within a directory."""
+
+    if not config_dir.exists():
+        raise FileNotFoundError(f"Config directory does not exist: {config_dir}")
+    configs: List[AccountConfig] = []
+    for path in sorted(config_dir.glob("*.yml")) + sorted(config_dir.glob("*.yaml")):
+        configs.append(load_account_config(path))
+    if not configs:
+        raise ValueError("No account configuration files found")
+    return configs
+
+
+def iter_config_files(config_dir: Path) -> Iterable[Path]:
+    """Iterate over configuration files in a directory."""
+
+    return list(sorted(config_dir.glob("*.yml")) + sorted(config_dir.glob("*.yaml")))

--- a/src/auction_bot/graphql.py
+++ b/src/auction_bot/graphql.py
@@ -1,0 +1,192 @@
+"""GraphQL client for Avtor24 interactions."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import httpx
+from tenacity import AsyncRetrying, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+LOGGER = logging.getLogger(__name__)
+
+API_URL = "https://avtor24.ru/api/graphql"  # placeholder endpoint
+
+
+@dataclass
+class GraphQLResponse:
+    """Container for GraphQL responses."""
+
+    data: Dict[str, Any]
+    errors: Optional[list[dict[str, Any]]]
+
+    def raise_for_errors(self) -> None:
+        if self.errors:
+            raise RuntimeError(f"GraphQL errors: {self.errors}")
+
+
+class Avtor24GraphQLClient:
+    """Thin async wrapper around HTTPX for GraphQL queries."""
+
+    def __init__(self, token: Optional[str] = None) -> None:
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        self._client = httpx.AsyncClient(headers=headers, timeout=20.0, http2=True)
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def execute(self, query: str, variables: Optional[Dict[str, Any]] = None) -> GraphQLResponse:
+        payload = {"query": query, "variables": variables or {}}
+        async for attempt in AsyncRetrying(
+            wait=wait_exponential(multiplier=0.5, min=1, max=8),
+            stop=stop_after_attempt(4),
+            retry=retry_if_exception_type(httpx.RequestError),
+            reraise=True,
+        ):
+            with attempt:
+                response = await self._client.post(API_URL, json=payload)
+                response.raise_for_status()
+                body = response.json()
+                return GraphQLResponse(data=body.get("data", {}), errors=body.get("errors"))
+        raise RuntimeError("GraphQL execution failed")
+
+    async def fetch_orders(self, filters: Dict[str, Any]) -> Dict[str, Any]:
+        response = await self.execute(_GET_AUCTION_WITH_CONSTRAINTS, {"filter": filters})
+        response.raise_for_errors()
+        return response.data["orders"]
+
+    async def mark_read(self, order_id: str) -> None:
+        result = await self.execute(_MARK_ORDER_READ, {"orderId": order_id})
+        result.raise_for_errors()
+
+    async def get_order_for_bid(self, order_id: str) -> Dict[str, Any]:
+        result = await self.execute(_GET_ORDER_FOR_BID, {"orderId": order_id})
+        result.raise_for_errors()
+        return result.data["order"]
+
+    async def get_bid_params(self, order_id: str) -> Dict[str, Any]:
+        result = await self.execute(_GET_BID_PARAMS, {"orderId": order_id})
+        result.raise_for_errors()
+        return result.data["bidParams"]
+
+    async def make_offer(
+        self,
+        order_id: str,
+        amount: float,
+        message: str,
+        captcha_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        variables = {
+            "orderId": order_id,
+            "amount": amount,
+            "message": message,
+            "captchaToken": captcha_token,
+        }
+        result = await self.execute(_MAKE_OFFER, variables)
+        result.raise_for_errors()
+        return result.data["makeOffer"]
+
+    async def send_message(self, dialog_id: str, text: str) -> None:
+        result = await self.execute(_ADD_COMMENT, {"dialogId": dialog_id, "text": text})
+        result.raise_for_errors()
+
+    async def fetch_dialogs(self) -> Dict[str, Any]:
+        result = await self.execute(_GET_DIALOGS, {})
+        result.raise_for_errors()
+        return result.data["dialogs"]
+
+
+# GraphQL queries (trimmed to the fields we require) -----------------------------------------------------
+
+_GET_AUCTION_WITH_CONSTRAINTS = """
+query GetAuctionWithConstraints($filter: OrdersFilter!) {
+  orders(filter: $filter) {
+    captcha
+    items {
+      id
+      title
+      createdAt
+      price
+      authorHasOffer
+      offersCount
+      subject { name }
+      workType { name }
+    }
+  }
+}
+"""
+
+_MARK_ORDER_READ = """
+mutation readOrder($orderId: ID!) {
+  readOrder(orderId: $orderId) { id }
+}
+"""
+
+_GET_ORDER_FOR_BID = """
+query getOrderForBid($orderId: ID!) {
+  order(id: $orderId) {
+    id
+    title
+    minPrice
+    maxPrice
+    authorHasOffer
+    currentAuthorBidWasHidden
+  }
+}
+"""
+
+_GET_BID_PARAMS = """
+query getBidParams($orderId: ID!) {
+  bidParams(orderId: $orderId) {
+    average
+    minimum
+    maximum
+  }
+}
+"""
+
+_MAKE_OFFER = """
+mutation makeOffer($orderId: ID!, $amount: Float!, $message: String!, $captchaToken: String) {
+  makeOffer(orderId: $orderId, amount: $amount, message: $message, captchaToken: $captchaToken) {
+    id
+    amount
+    status
+  }
+}
+"""
+
+_ADD_COMMENT = """
+mutation addComment($dialogId: ID!, $text: String!) {
+  addComment(dialogId: $dialogId, text: $text) {
+    id
+  }
+}
+"""
+
+_GET_DIALOGS = """
+query getDialogs {
+  dialogs {
+    id
+    orderId
+    unreadCount
+    lastMessage {
+      id
+      text
+      createdAt
+    }
+  }
+}
+"""
+
+
+async def create_client_with_login(login_coro: Any) -> Avtor24GraphQLClient:
+    """Helper to create a client after completing a login coroutine."""
+
+    token = await asyncio.ensure_future(login_coro)
+    return Avtor24GraphQLClient(token=token)
+
+
+__all__ = ["Avtor24GraphQLClient", "GraphQLResponse", "create_client_with_login"]

--- a/src/auction_bot/queue.py
+++ b/src/auction_bot/queue.py
@@ -1,0 +1,100 @@
+"""Priority queue implementation for auction orders."""
+from __future__ import annotations
+
+import heapq
+import time
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Iterator, Optional
+
+
+@dataclass(order=True)
+class PrioritisedOrder:
+    """Internal wrapper for heap ordering."""
+
+    priority: float
+    order_id: str = field(compare=False)
+    payload: "Order" = field(compare=False)
+
+
+@dataclass
+class Order:
+    """Simplified order representation used inside the bot."""
+
+    id: str
+    title: str
+    created_at: float
+    budget: Optional[int]
+    author_has_offer: bool
+    offers_count: int
+    subject: Optional[str] = None
+    work_type: Optional[str] = None
+
+    def freshness_score(self) -> float:
+        """Calculate a freshness score based on creation time."""
+
+        age_seconds = max(time.time() - self.created_at, 1.0)
+        return 1.0 / age_seconds
+
+
+class OrderQueue:
+    """Maintain a priority queue of orders preferring newer items."""
+
+    def __init__(self) -> None:
+        self._heap: list[PrioritisedOrder] = []
+        self._index: Dict[str, PrioritisedOrder] = {}
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._index)
+
+    def __iter__(self) -> Iterator[Order]:
+        return (entry.payload for entry in sorted(self._heap))
+
+    def _compute_priority(self, order: Order) -> float:
+        """Combine multiple factors into a single priority value."""
+
+        freshness = order.freshness_score()
+        penalty = 0.0
+        if order.author_has_offer:
+            penalty += 1.0
+        penalty += min(order.offers_count, 10) * 0.05
+        return -(freshness - penalty)
+
+    def upsert(self, order: Order) -> None:
+        """Insert or update an order in the queue."""
+
+        priority = self._compute_priority(order)
+        if order.id in self._index:
+            existing = self._index[order.id]
+            existing.priority = priority
+            existing.payload = order
+            heapq.heapify(self._heap)
+        else:
+            entry = PrioritisedOrder(priority=priority, order_id=order.id, payload=order)
+            self._index[order.id] = entry
+            heapq.heappush(self._heap, entry)
+
+    def pop(self) -> Optional[Order]:
+        """Retrieve the best order available."""
+
+        while self._heap:
+            entry = heapq.heappop(self._heap)
+            if entry.order_id in self._index and self._index[entry.order_id] is entry:
+                del self._index[entry.order_id]
+                return entry.payload
+        return None
+
+    def bulk_update(self, orders: Iterable[Order]) -> None:
+        """Add or refresh multiple orders at once."""
+
+        for order in orders:
+            self.upsert(order)
+
+    def discard(self, order_id: str) -> None:
+        """Remove an order from the queue if it exists."""
+
+        entry = self._index.pop(order_id, None)
+        if entry is not None:
+            entry.payload = None  # type: ignore[assignment]
+
+
+__all__ = ["Order", "OrderQueue"]

--- a/src/auction_bot/scheduler.py
+++ b/src/auction_bot/scheduler.py
@@ -1,0 +1,66 @@
+"""Simple scheduler for delayed tasks."""
+from __future__ import annotations
+
+import asyncio
+import heapq
+import time
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Coroutine, Optional
+
+
+@dataclass(order=True)
+class ScheduledTask:
+    execute_at: float
+    callback: Callable[[], Awaitable[None]] = field(compare=False)
+    id: str = field(default_factory=lambda: str(time.time()), compare=False)
+
+
+class TaskScheduler:
+    """Lightweight scheduler for delayed async callbacks."""
+
+    def __init__(self) -> None:
+        self._tasks: list[ScheduledTask] = []
+        self._event = asyncio.Event()
+        self._running = False
+
+    async def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        asyncio.create_task(self._runner())
+
+    async def stop(self) -> None:
+        self._running = False
+        self._event.set()
+
+    async def schedule(self, delay_seconds: float, callback: Callable[[], Awaitable[None]]) -> None:
+        execute_at = time.time() + delay_seconds
+        heapq.heappush(self._tasks, ScheduledTask(execute_at, callback))
+        self._event.set()
+
+    async def _runner(self) -> None:
+        while self._running:
+            now = time.time()
+            if not self._tasks:
+                self._event.clear()
+                await self._event.wait()
+                continue
+            next_task = self._tasks[0]
+            if next_task.execute_at > now:
+                wait_time = min(next_task.execute_at - now, 10.0)
+                try:
+                    await asyncio.wait_for(self._event.wait(), timeout=wait_time)
+                except asyncio.TimeoutError:
+                    pass
+                self._event.clear()
+                continue
+            heapq.heappop(self._tasks)
+            try:
+                await next_task.callback()
+            except Exception:  # pragma: no cover - defensive logging
+                import logging
+
+                logging.getLogger(__name__).exception("Scheduled task failed")
+
+
+__all__ = ["TaskScheduler"]

--- a/src/auction_bot/worker.py
+++ b/src/auction_bot/worker.py
@@ -1,0 +1,198 @@
+"""Account worker orchestrating fetching, bidding, and messaging."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from . import browser
+from .config import AccountConfig, MessageTemplate
+from .graphql import Avtor24GraphQLClient
+from .queue import Order, OrderQueue
+from .scheduler import TaskScheduler
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class BidContext:
+    order: Order
+    bid_amount: float
+    message: str
+    captcha_required: bool
+
+
+class AccountWorker:
+    """Handle a single Avtor24 account."""
+
+    def __init__(
+        self,
+        config: AccountConfig,
+        graphql_client: Avtor24GraphQLClient,
+        task_scheduler: Optional[TaskScheduler] = None,
+    ) -> None:
+        self.config = config
+        self.graphql = graphql_client
+        self.queue = OrderQueue()
+        self.scheduler = task_scheduler or TaskScheduler()
+        self._running = False
+        self._last_bid_at: float = 0.0
+
+    async def start(self) -> None:
+        self._running = True
+        await self.scheduler.start()
+        await self._run()
+
+    async def stop(self) -> None:
+        self._running = False
+        await self.scheduler.stop()
+
+    async def _run(self) -> None:
+        async with browser.playwright_session(self.config.storage_path, headless=self.config.headless) as session:
+            await session.ensure_logged_in(self.config.login, self.config.password)
+            while self._running:
+                try:
+                    await self._tick(session)
+                except Exception as exc:  # pragma: no cover - runtime resilience
+                    LOGGER.exception("Worker %s encountered an error: %s", self.config.name, exc)
+                    await asyncio.sleep(5)
+
+    async def _tick(self, session: browser.BrowserSession) -> None:
+        await self._refresh_queue()
+        bid_context = await self._select_bid_candidate()
+        if not bid_context:
+            await asyncio.sleep(2)
+            return
+        await self._respect_bid_interval()
+        await self._perform_bid(session, bid_context)
+
+    async def _refresh_queue(self) -> None:
+        filters = self._build_filters()
+        payload = await self.graphql.fetch_orders(filters)
+        captcha_required = payload.get("captcha", False)
+        items = payload.get("items", [])
+        orders = []
+        for item in items:
+            order = Order(
+                id=item["id"],
+                title=item.get("title", ""),
+                created_at=self._parse_timestamp(item.get("createdAt")),
+                budget=item.get("price"),
+                author_has_offer=item.get("authorHasOffer", False),
+                offers_count=item.get("offersCount", 0),
+                subject=(item.get("subject") or {}).get("name"),
+                work_type=(item.get("workType") or {}).get("name"),
+            )
+            orders.append(order)
+        self.queue.bulk_update(orders)
+        if captcha_required:
+            LOGGER.warning("Captcha required for account %s, manual interaction needed", self.config.name)
+
+    async def _select_bid_candidate(self) -> Optional[BidContext]:
+        order = self.queue.pop()
+        if not order:
+            return None
+        await self.graphql.mark_read(order.id)
+        order_details = await self.graphql.get_order_for_bid(order.id)
+        bid_params = await self.graphql.get_bid_params(order.id)
+        amount = self._calculate_bid_amount(order, order_details, bid_params)
+        template = self._select_template(order)
+        message = template.text if template else "Здравствуйте! Готов взяться за заказ."
+        captcha_required = bool(order_details.get("currentAuthorBidWasHidden"))
+        return BidContext(order=order, bid_amount=amount, message=message, captcha_required=captcha_required)
+
+    def _calculate_bid_amount(self, order: Order, order_details: Dict[str, any], bid_params: Dict[str, any]) -> float:
+        avg = bid_params.get("average")
+        minimum = bid_params.get("minimum")
+        maximum = bid_params.get("maximum")
+        fallback = order.budget or maximum or minimum or avg or 500.0
+        if avg and maximum:
+            bid = (avg + maximum) / 2
+        elif maximum:
+            bid = maximum * 0.9
+        elif avg:
+            bid = avg
+        else:
+            bid = fallback
+        min_budget = self.config.filters.min_budget
+        if min_budget and bid < min_budget:
+            bid = float(min_budget)
+        return float(bid)
+
+    def _select_template(self, order: Order) -> Optional[MessageTemplate]:
+        for template in self.config.message_templates:
+            if order.subject and order.subject in template.name:
+                return template
+        return self.config.message_templates[0] if self.config.message_templates else None
+
+    async def _perform_bid(self, session: browser.BrowserSession, bid_context: BidContext) -> None:
+        order = bid_context.order
+        LOGGER.info("Placing bid on %s (%s) for %.2f", order.title, order.id, bid_context.bid_amount)
+        await session.open_order(order.id)
+        await session.place_bid(bid_context.bid_amount, bid_context.message, captcha_required=bid_context.captcha_required)
+        await self.graphql.make_offer(order.id, bid_context.bid_amount, bid_context.message)
+        self._last_bid_at = time.time()
+        await self._schedule_followup(order, session)
+
+    async def _schedule_followup(self, order: Order, session: browser.BrowserSession) -> None:
+        if not self.config.message_templates:
+            return
+        followup_template = next(
+            (tpl for tpl in self.config.message_templates if tpl.delay_seconds > 0),
+            None,
+        )
+        if not followup_template and len(self.config.message_templates) > 1:
+            followup_template = self.config.message_templates[1]
+        if not followup_template:
+            return
+
+        delay = (
+            followup_template.delay_seconds
+            if followup_template.delay_seconds > 0
+            else self.config.follow_up_delay_minutes * 60
+        )
+
+        async def _send() -> None:
+            LOGGER.info("Sending follow-up for %s", order.id)
+            await session.send_followup_message(followup_template.text)
+
+        await self.scheduler.schedule(delay, _send)
+
+    async def _respect_bid_interval(self) -> None:
+        elapsed = time.time() - self._last_bid_at
+        min_wait = self.config.min_seconds_between_bids
+        max_wait = self.config.max_seconds_between_bids
+        target = random.uniform(min_wait, max_wait)
+        if elapsed < target:
+            await asyncio.sleep(target - elapsed)
+
+    def _build_filters(self) -> Dict[str, any]:
+        filters: Dict[str, any] = {
+            "subjects": self.config.filters.subjects,
+            "workTypes": self.config.filters.work_types,
+        }
+        if self.config.filters.min_budget is not None:
+            filters["minPrice"] = self.config.filters.min_budget
+        if self.config.filters.max_budget is not None:
+            filters["maxPrice"] = self.config.filters.max_budget
+        return filters
+
+    def _parse_timestamp(self, iso_timestamp: Optional[str]) -> float:
+        if not iso_timestamp:
+            return time.time()
+        try:
+            return time.mktime(time.strptime(iso_timestamp.split(".")[0], "%Y-%m-%dT%H:%M:%S"))
+        except ValueError:
+            return time.time()
+
+
+async def run_workers(configs: List[AccountConfig]) -> None:
+    clients = [Avtor24GraphQLClient() for _ in configs]
+    workers = [AccountWorker(cfg, client) for cfg, client in zip(configs, clients)]
+    await asyncio.gather(*(worker.start() for worker in workers))
+
+
+__all__ = ["AccountWorker", "run_workers"]


### PR DESCRIPTION
## Summary
- add a Python package that orchestrates configuration loading, GraphQL access, and worker logic for Avtor24 accounts
- implement Playwright-driven browser automation, task scheduling, and priority queuing to process auctions
- document usage with a README and include an example per-account configuration file

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d7e8a5cf448332a7c30bd0635af964